### PR TITLE
Feature/accessibility considerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Once onApi returns, you can use the API to query hexagon dimensions. `screenCoor
 ```
   const el = document.querySelector('abcnews-hexmap');
   el.onApi = function (api) {
+    // Get hex info
     console.log(api.getHex('BRIS'));
     // {
     //   "code": "BRIS",
@@ -47,6 +48,9 @@ Once onApi returns, you can use the API to query hexagon dimensions. `screenCoor
     //     112
     //   ]
     // }
+
+    // put keyboard focus on the given hex
+    api.focusHex('BRIS');
   };
 ```
 

--- a/src/components/HexMap/HexMap.svelte
+++ b/src/components/HexMap/HexMap.svelte
@@ -48,7 +48,9 @@
     /** Party for whom to show first preference arrows */
     arrowChart = 'None',
     /** which electorate is currently focused */
-    selectedElectorate = null
+    selectedElectorate = null,
+    /** Additional text to add to the alt text version of each electorate, e.g. `{ ADEL: 'ALP retain' }` */
+    customElectorateAltText
   } = $props();
   let svgEl = $state<SVGElement>();
   let svgRatio = $state(0);
@@ -169,6 +171,7 @@
 
   {#if isInteractive}
     <HexMapKeyboardNav
+      {customElectorateAltText}
       groups={config.groups}
       {layout}
       onChange={newValue => {

--- a/src/components/HexMap/HexMapKeyboardNav/HexMapKeyboardNav.svelte
+++ b/src/components/HexMap/HexMapKeyboardNav/HexMapKeyboardNav.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import AccessibleHide from '../../AccessibleHide/AccesibleHide.svelte';
   import SkipLink from '../../SkipLink/SkipLink.svelte';
-  let { groups, layout, onChange, onClick, onFocus } = $props();
+  let { groups, layout, onChange, onClick, onFocus, customElectorateAltText = {} } = $props();
   let focused = $state(null);
   function onFocusProxy(e) {
     const id = e.target.dataset.id;
@@ -55,7 +55,7 @@
         <ul>
           {#each group.hexes as hex}
             <li>
-              <button data-id={hex.id}>{hex.name}</button>
+              <button data-id={hex.id}>{hex.name} {customElectorateAltText[hex.id] || ''}</button>
             </li>
           {/each}
         </ul>

--- a/src/components/HexMap/HexMapKeyboardNav/HexMapKeyboardNav.svelte
+++ b/src/components/HexMap/HexMapKeyboardNav/HexMapKeyboardNav.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
   import AccessibleHide from '../../AccessibleHide/AccesibleHide.svelte';
+  import SkipLink from '../../SkipLink/SkipLink.svelte';
   let { groups, layout, onChange, onClick, onFocus } = $props();
   let focused = $state(null);
   function onFocusProxy(e) {
     const id = e.target.dataset.id;
-    focused = id
+    focused = id;
 
     onFocus?.({
       code: id
-    })
+    });
   }
   function onClickProxy(e) {
     const id = e.target.dataset.id;
@@ -26,7 +27,7 @@
       focused = null;
     }
 
-    onFocus?.({code: null})
+    onFocus?.({ code: null });
   }
   $effect(() => {
     onChange?.(focused);
@@ -43,6 +44,7 @@
   );
 </script>
 
+<SkipLink id="hex-map-top" target="hex-map-bottom" position="topleft">Skip past map</SkipLink>
 <AccessibleHide>
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
@@ -61,6 +63,7 @@
     {/each}
   </ul>
 </AccessibleHide>
+<SkipLink id="hex-map-bottom" target="hex-map-top" position="bottomleft">Skip above map</SkipLink>
 
 <style lang="scss">
   .hexmapkeyboardnav {

--- a/src/components/SkipLink/SkipLink.svelte
+++ b/src/components/SkipLink/SkipLink.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  let { id, target, children, position = 'topleft' } = $props();
+  let anchor = $derived.by(() => `#${target}`);
+</script>
+
+<a
+  {id}
+  href={anchor}
+  class={`skip-link--${position}`}
+  onclick={e => {
+    e.preventDefault();
+    const element = document.querySelector(anchor);
+    if (!(element instanceof HTMLAnchorElement)) {
+      return;
+    }
+
+    element.focus();
+  }}
+>
+  {@render children?.()}
+</a>
+
+<style lang="scss">
+  a {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1.3rem;
+    padding: 0.3rem 0.6rem 0.1rem;
+    text-decoration: none;
+    letter-spacing: 0.125rem;
+    text-transform: uppercase;
+    color: #fff;
+    background-color: #0058cc;
+    transition: opacity 0.2s;
+    position: absolute;
+  }
+  a:focus {
+    opacity: 1;
+  }
+  a:not(:focus) {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+    opacity: 0.1;
+  }
+
+  .skip-link--topleft {
+    left: 1rem;
+    top: 1rem;
+  }
+  .skip-link--bottomleft {
+    left: 1rem;
+    bottom: 1rem;
+  }
+</style>

--- a/src/webcomponent/HexMapWebComponent.svelte
+++ b/src/webcomponent/HexMapWebComponent.svelte
@@ -31,7 +31,7 @@
     colours
   } = $props();
 
-  let rootEl = $state();
+  let rootEl = $state<HTMLDivElement>();
 
   let layoutDefinition = $derived.by(() => layouts[layout]);
 
@@ -53,7 +53,7 @@
   function getHex(id: string) {
     const hex = electoratesByCode[id];
     const groupOffset = layoutDefinition.positions[hex?.group];
-    if (!(rootEl instanceof HTMLDivElement)) {
+    if (!rootEl) {
       return;
     }
     const svg = rootEl.querySelector('svg');
@@ -78,11 +78,19 @@
     };
   }
 
+  function focusHex(id) {
+    const buttonElement = rootEl?.querySelector(`.hexmapkeyboardnav button[data-id="${id}"]`);
+    if (!(buttonElement instanceof HTMLButtonElement)) {
+      return;
+    }
+    buttonElement.focus();
+  }
+
   $effect(() => {
     if (!onApi) {
       return;
     }
-    onApi({ getHex });
+    onApi({ getHex, focusHex });
   });
 </script>
 

--- a/src/webcomponent/HexMapWebComponent.svelte
+++ b/src/webcomponent/HexMapWebComponent.svelte
@@ -28,7 +28,8 @@
     onViewboxChange = () => {},
     isStaticLayout = true,
     isInteractive = true,
-    colours
+    colours,
+    customElectorateAltText = {}
   } = $props();
 
   let rootEl = $state<HTMLDivElement>();
@@ -112,5 +113,6 @@
     {isStaticLayout}
     {isInteractive}
     {onViewboxChange}
+    {customElectorateAltText}
   />
 </div>


### PR DESCRIPTION
* [feature: focusHex method in the API](https://github.com/abcnews/elections-federal2025-lower-house/commit/40cb278892b3162a6bc13654800d0921257158c7) - use this to return focus when the modal closes
* [feature: skip links to get past hex map list](https://github.com/abcnews/elections-federal2025-lower-house/commit/0937a93027a4b0ccfad9de42dbf68fe78ab5bc7d) - you don't need to do anything, this just works
* [feature: custom status text on alt text electorates](https://github.com/abcnews/elections-federal2025-lower-house/commit/88decc57729dfe19913ba888fd00c11bae2eae2b) - provide any status text as required. This might be tricky, since the logic seems to be all in your GainRetain component, but now you have the option :)